### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,6 @@ env:
   global:
     - secure: "VSpfLQ+8CziLvcYi5Fab4KhOTepQtJ/43V8kLsX+pdy+NkxG8ENnmxQlPiPf8hGdqnYGkMoWNq8xhJjz3puv2LbwiBT8NBzm/AllcFQa8NhzWercPZRWA7ezJbfrMiyJ61ZAXnBdC0xwPVHPGnjaDmg5WAFiOeftTntxtAr0RMo="
     - secure: "BARiNKOHG3a/UYkbVL6RLS1EX/UDFj8z7OKFYb2LjpFSrseQKG2FypoBZyLutJ7TLl38OY9DqhxRdwMohy6mr/Q1/f2vNnBud8omMj9a2UfxY+dr4adPyHN2agRnxupCVAuxwdH9jCagNQcc5phrDRPJPHNrxsAX5klM+LOACJ0="
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
